### PR TITLE
Show description to users of Zed

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "tact"
 name = "Tact"
-description = "Tact language support. Needs Tact Standard Library: npm install @tact-lang/compiler"
+description = "Tact is a fresh programming language for TON Blockchain that is focused on efficiency and ease of development. You need the Tact Standard Library: npm install @tact-lang/compiler"
 version = "0.0.1"
 schema_version = 1
 authors = ["Mikal Sande <mikal.sande@gmail.com>"]


### PR DESCRIPTION
I find that looking through Zed's extensions for new extensions is a good way to discover new and interesting technology.  If someone created a Zed extension they cared enough to make an investment in making that technology easier to use from Zed.  

This proposed change adds information that would let others exploring extensions decide whether they want to dig deeper.